### PR TITLE
Support 32-bit RGB image rendering in android_nativewindow

### DIFF
--- a/ijkmedia/ijksdl/android/android_nativewindow.c
+++ b/ijkmedia/ijksdl/android/android_nativewindow.c
@@ -99,7 +99,6 @@ static int android_render_on_yv12(ANativeWindow_Buffer *out_buffer, const SDL_Vo
 static int android_render_rgb_on_rgb(ANativeWindow_Buffer *out_buffer, const SDL_VoutOverlay *overlay, int bpp)
 {
     // SDLTRACE("SDL_VoutAndroid: android_render_rgb_on_rgb(%p)", overlay);
-    assert(overlay->format == SDL_FCC_RV16);
     assert(overlay->planes == 1);
 
     int min_height = IJKMIN(out_buffer->height, overlay->h);


### PR DESCRIPTION
fix for issue [131](https://github.com/debugly/ijkplayer/issues/131)